### PR TITLE
[PR] Image Rendering Bug (#2) Fix

### DIFF
--- a/t3-stack/next.config.mjs
+++ b/t3-stack/next.config.mjs
@@ -14,7 +14,7 @@ const config = {
     defaultLocale: "en",
   },
   images: {
-    domains: ["https://raw.githubusercontent.com", "localhost", "lh3.googleusercontent.com"],
+    domains: ["raw.githubusercontent.com", "localhost", "lh3.googleusercontent.com"],
   },
 };
 export default config;

--- a/t3-stack/src/components/Layout.tsx
+++ b/t3-stack/src/components/Layout.tsx
@@ -1,12 +1,12 @@
 import Head from 'next/head';
 import { useSession } from 'next-auth/react';
 import { Avatar } from '@nextui-org/react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { signIn, signOut } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import { Puff } from 'react-loader-spinner';
-import {type Session } from 'next-auth';
+import { type Session } from 'next-auth';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -15,9 +15,13 @@ interface LayoutProps {
   session?: Session | null;
 }
 
-export default function Layout({ children, home, image, session }: LayoutProps) {
+interface AuthProps {
+  sessionData: Session | null | undefined;
+}
 
+export default function Layout({ children, home, image, session }: LayoutProps) {
   const [isNavigating, setIsNavigating] = useState(false);
+  const [sessionData, setSessionData] = useState<Session | null | undefined>(session);
 
   const router = useRouter();
   const navigateProfile = () => {
@@ -31,6 +35,10 @@ export default function Layout({ children, home, image, session }: LayoutProps) 
     });
   };
 
+  useEffect(() => {
+    setSessionData(session);
+  }, [session]);
+
   if (home) {
     return (
       <>
@@ -41,7 +49,7 @@ export default function Layout({ children, home, image, session }: LayoutProps) 
         </Head>
         <main className='flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#2e026d] to-[#15162c] pb-16'>
           <div className='container mr-16 mb-16 flex flex-row items-center justify-end gap-16'>
-            {image ? (
+            {sessionData ? (
               <div className='flex flex-col items-center justify-center gap-4'>
                 {isNavigating ? (
                   <Puff
@@ -57,7 +65,8 @@ export default function Layout({ children, home, image, session }: LayoutProps) 
                 ) : (
                   <Avatar
                     size='lg'
-                    src={image ? image : ''}
+                    src={sessionData.user?.image as string}
+                    alt='Profile Picture'
                     loading='eager'
                     bordered
                     color='gradient'
@@ -95,7 +104,7 @@ export default function Layout({ children, home, image, session }: LayoutProps) 
             </h1>
 
             <div className='flex flex-col items-center gap-6'>
-              <Auth />
+              <Auth sessionData={session} />
               <NavigateToGuestBook />
             </div>
           </div>
@@ -107,9 +116,7 @@ export default function Layout({ children, home, image, session }: LayoutProps) 
   }
 }
 
-const Auth: React.FC = () => {
-  const { data: sessionData } = useSession();
-
+const Auth = ({ sessionData }: AuthProps) => {
   return (
     <div className='flex flex-col items-center justify-center gap-4'>
       <p className='pb-8 text-center text-2xl text-white'>

--- a/t3-stack/src/components/Layout.tsx
+++ b/t3-stack/src/components/Layout.tsx
@@ -1,20 +1,22 @@
 import Head from 'next/head';
 import { useSession } from 'next-auth/react';
 import { Avatar } from '@nextui-org/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { signIn, signOut } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import { Puff } from 'react-loader-spinner';
+import {type Session } from 'next-auth';
 
 interface LayoutProps {
   children: React.ReactNode;
   home?: boolean;
+  image?: string | null | undefined;
+  session?: Session | null;
 }
 
-export default function Layout({ children, home }: LayoutProps) {
-  const { data: session } = useSession();
-  const [image, setImage] = useState<string | undefined>(`${session?.user?.image} ? ${session?.user?.image} : ''`);
+export default function Layout({ children, home, image, session }: LayoutProps) {
+
   const [isNavigating, setIsNavigating] = useState(false);
 
   const router = useRouter();
@@ -29,12 +31,6 @@ export default function Layout({ children, home }: LayoutProps) {
     });
   };
 
-  useEffect(() => {
-    if (session?.user?.image) {
-      setImage(session.user.image);
-    }
-  }, [session]);
-
   if (home) {
     return (
       <>
@@ -45,7 +41,7 @@ export default function Layout({ children, home }: LayoutProps) {
         </Head>
         <main className='flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#2e026d] to-[#15162c] pb-16'>
           <div className='container mr-16 mb-16 flex flex-row items-center justify-end gap-16'>
-            {session?.user?.image ? (
+            {image ? (
               <div className='flex flex-col items-center justify-center gap-4'>
                 {isNavigating ? (
                   <Puff
@@ -61,7 +57,8 @@ export default function Layout({ children, home }: LayoutProps) {
                 ) : (
                   <Avatar
                     size='lg'
-                    src={image}
+                    src={image ? image : ''}
+                    loading='eager'
                     bordered
                     color='gradient'
                     className='hover:cursor-pointer'
@@ -69,7 +66,7 @@ export default function Layout({ children, home }: LayoutProps) {
                   />
                 )}
                 <h1 className='text-sm font-extrabold tracking-tight text-white'>
-                  {session.user?.name}
+                  {session?.user?.name}
                 </h1>
               </div>
             ) : null}

--- a/t3-stack/src/pages/index.tsx
+++ b/t3-stack/src/pages/index.tsx
@@ -1,10 +1,13 @@
 import { type NextPage } from 'next';
 import Layout from '../components/Layout';
+import { useSession } from 'next-auth/react';
 
 const Home: NextPage = () => {
+  const { data: session } = useSession();
+
   return (
     <div>
-      <Layout home>
+      <Layout home image={session?.user?.image} session={session}>
         <h1>Home</h1>
       </Layout>
     </div>


### PR DESCRIPTION
Took advantage of React's one way binding and moved the `useSession()` hook up the component hierarchy. Now, every layout will have props on the session, image, etc. This change also made it so the auth component can be fed the props as well.


**/components/layout.tsx**

```TypeScript
interface LayoutProps {
  children: React.ReactNode;
  home?: boolean;
  image?: string | null | undefined;
  session?: Session | null;
}

interface AuthProps {
  sessionData: Session | null | undefined;
}
```

**/pages/index.tsx**
```TypeScript
const Home: NextPage = () => {
  const { data: session } = useSession();

  return (
    <div>
      <Layout home image={session?.user?.image} session={session}>
      ......
    </div>
)
```

**/components/layout.tsx**
```TypeScript

// Example(s), see src for actual implementation.

const Auth = ({ sessionData }: AuthProps) => {
  return (
    <div className='flex flex-col items-center justify-center gap-4'>
      .... Hello, {sessionData.user?.name}!
    </div>
  );
};


export default function Layout({ children, home, image, session }: LayoutProps) {
  return (
      <div>
        <Image src={image}/>
        <Auth sessionData={session} />
     </div> 
  )
}

```